### PR TITLE
Disconnect after send failures

### DIFF
--- a/iluflex_tools/core/services.py
+++ b/iluflex_tools/core/services.py
@@ -124,10 +124,18 @@ class ConnectionService:
             self._sock.sendall(payload)
             self._emit({"type": "tx", "ts": ts, "remote": self._remote, "text": dbg, "raw": payload})
             return True
+        except (BrokenPipeError, ConnectionResetError, OSError) as e:
+            print(f"[TX] erro: {e}")
+            ts = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+            self._emit({"type": "error", "ts": ts, "remote": self._remote, "text": f"tx error: {e}"})
+            # garantir que listeners recebam o evento de disconnect
+            self.disconnect()
+            return False
         except Exception as e:
             print(f"[TX] erro: {e}")
             ts = datetime.now().strftime("%H:%M:%S.%f")[:-3]
             self._emit({"type": "error", "ts": ts, "remote": self._remote, "text": f"tx error: {e}"})
+            self.disconnect()
             return False
 
 # --------- OTA Services ---------


### PR DESCRIPTION
## Summary
- ensure ConnectionService triggers disconnect after send errors so UI listeners update

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10e934ad08325bddfaa3a4a157dd6