### PR TITLE
Add reusable status LED widget for connection status

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ C:/Users/SEUUSER/AppData/Local/Programs/Python/Python313/python.exe -m pip insta
 C:/Users/SEUUSER/AppData/Local/Programs/Python/Python313/python.exe main.py
 ```
 ## Comandos para gerar executável com Installer
+
+## Status LED
+
+Para exibir o estado da conexão em qualquer página, use o widget `StatusLed`.
+
+```python
+from iluflex_tools.widgets.status_led import StatusLed
+
+led = StatusLed(parent)
+led.bind_conn(conn)  # instância de ConnectionService
+```
+
+O LED fica verde quando conectado e vermelho ao desconectar.
+

--- a/iluflex_tools/ui/pages/comandos_ir.py
+++ b/iluflex_tools/ui/pages/comandos_ir.py
@@ -1,5 +1,6 @@
 import customtkinter as ctk
 from iluflex_tools.widgets.waveform_canvas import WaveformCanvas
+from iluflex_tools.widgets.status_led import StatusLed
 
 class ComandosIRPage(ctk.CTkFrame):
     """
@@ -86,9 +87,12 @@ class ComandosIRPage(ctk.CTkFrame):
         self.entry.pack(side="left", padx=(0, 8))
         ctk.CTkButton(sendcmd_frame, text="Enviar", command=self._send).pack(side="left", padx=(0, 8))
 
-        # status message
-        self.status = ctk.CTkLabel(self, text="")
-        self.status.grid(row=9, column=0, sticky="w", padx=10, pady=(0,10))
+        status_frame = ctk.CTkFrame(self)
+        status_frame.grid(row=9, column=0, sticky="w", padx=10, pady=(0,10))
+        self.status_led = StatusLed(status_frame, conn=self.conn)
+        self.status_led.pack(side="left", padx=(0,6))
+        self.status = ctk.CTkLabel(status_frame, text="")
+        self.status.pack(side="left")
 
 
 
@@ -136,7 +140,7 @@ class ComandosIRPage(ctk.CTkFrame):
             self._append("[warn] não conectado; mensagem não enviada.\n")
 
     def _clear(self):
-            self.status.configure(text="")
+        self.status.configure(text="")
 
     # ---- eventos da conexão ----
     def _on_conn_event(self, ev: dict):
@@ -147,10 +151,8 @@ class ComandosIRPage(ctk.CTkFrame):
         t = ev.get("ts", "--:--:--.---")
         typ = ev.get("type")
         if typ == "connect":
-            self.status.configure(text=f"Conectado a {ev.get('remote')}")
             self._append(f"[{t}] CONNECT {ev.get('remote')}\n")
         elif typ == "disconnect":
-            self.status.configure(text="Desconectado.")
             self._append(f"[{t}] DISCONNECT\n")
         elif typ == "tx":
             self._append(f"[{t}] TX: {ev.get('text','')}")  # já vem com \n se você mandar

--- a/iluflex_tools/ui/pages/conexao.py
+++ b/iluflex_tools/ui/pages/conexao.py
@@ -2,6 +2,7 @@ import threading
 import customtkinter as ctk
 from iluflex_tools.widgets.column_tree import ColumnToggleTree
 from iluflex_tools.core.services import ConnectionService
+from iluflex_tools.widgets.status_led import StatusLed
 
 class ConexaoPage(ctk.CTkFrame):
     def __init__(
@@ -23,11 +24,6 @@ class ConexaoPage(ctk.CTkFrame):
         self._scan_thread = None
         self._conn = conn
         self._build()
-        try:
-            if self._conn is not None:
-                self._conn.add_listener(self._on_conn_event)
-        except Exception:
-            pass
 
     def _build(self):
         self.grid_columnconfigure(1, weight=1)
@@ -82,8 +78,12 @@ class ConexaoPage(ctk.CTkFrame):
         ctk.CTkButton(btns, text="Conectar", command=self._connect).pack(side="left", padx=6)
         ctk.CTkButton(btns, text="Desconectar", command=self._disconnect).pack(side="left", padx=6)
 
-        self.status = ctk.CTkLabel(self, text="Pronto.")
-        self.status.grid(row=5, column=0, columnspan=3, pady=6)
+        status_frame = ctk.CTkFrame(self)
+        status_frame.grid(row=5, column=0, columnspan=3, pady=6)
+        self.status_led = StatusLed(status_frame, conn=self._conn)
+        self.status_led.pack(side="left", padx=(0,6))
+        self.status = ctk.CTkLabel(status_frame, text="Pronto.")
+        self.status.pack(side="left")
 
     # ---- Ações ----
     def _on_row_double_click(self, _event=None):
@@ -188,18 +188,5 @@ class ConexaoPage(ctk.CTkFrame):
             cur.append(row)
             self.table.set_rows(cur)
 
-    # ---- Eventos de conexão ----
-    def _on_conn_event(self, ev: dict):
-        try:
-            if ev.get("type") == "disconnect":
-                self.after(0, lambda: self.status.configure(text="Desconectado."))
-        except Exception:
-            pass
-
     def destroy(self):
-        try:
-            if self._conn is not None:
-                self._conn.remove_listener(self._on_conn_event)
-        except Exception:
-            pass
         return super().destroy()

--- a/iluflex_tools/widgets/status_led.py
+++ b/iluflex_tools/widgets/status_led.py
@@ -1,0 +1,51 @@
+import customtkinter as ctk
+from iluflex_tools.core.services import ConnectionService
+
+class StatusLed(ctk.CTkFrame):
+    """Pequeno indicador em forma de LED para status de conexão."""
+    def __init__(self, master, conn: ConnectionService | None = None, size: int = 12, **kwargs):
+        super().__init__(master, width=size, height=size, **kwargs)
+        self._size = size
+        self._conn: ConnectionService | None = None
+        self._listener = lambda ev: self._on_event(ev)
+        self.canvas = ctk.CTkCanvas(self, width=size, height=size, highlightthickness=0)
+        self.canvas.pack()
+        self._set_color("#666666")
+        if conn is not None:
+            self.bind_conn(conn)
+
+    def _set_color(self, color: str):
+        s = self._size
+        self.canvas.delete("all")
+        self.canvas.create_oval(1, 1, s - 1, s - 1, fill=color, outline="")
+
+    def _on_event(self, ev: dict):
+        typ = ev.get("type")
+        if typ == "connect":
+            self._set_color("#2ecc71")  # verde
+        elif typ == "disconnect":
+            self._set_color("#e74c3c")  # vermelho
+        elif typ == "error":
+            self._set_color("#e67e22")  # laranja
+
+    def bind_conn(self, conn: ConnectionService | None):
+        if self._conn is not None:
+            try:
+                self._conn.remove_listener(self._listener)
+            except Exception:
+                pass
+        self._conn = conn
+        if conn is not None:
+            try:
+                conn.add_listener(self._listener)
+                self._set_color("#2ecc71" if conn.connected else "#e74c3c")
+            except Exception:
+                pass
+
+    def destroy(self):
+        try:
+            if self._conn is not None:
+                self._conn.remove_listener(self._listener)
+        except Exception:
+            pass
+        return super().destroy()


### PR DESCRIPTION
## Summary
- add `StatusLed` widget to display connection status by listening to `ConnectionService` events
- refactor `ConexaoPage` and `ComandosIRPage` to use the shared LED indicator
- document how to embed and bind the status LED widget

## Testing
- `python3 -m py_compile iluflex_tools/widgets/status_led.py iluflex_tools/ui/pages/conexao.py iluflex_tools/ui/pages/comandos_ir.py`


------
https://chatgpt.com/codex/tasks/task_e_68a10eb3b0e48325a6eb979e5a38a430