### PR TITLE
feat: add auto reconnect option

### DIFF
--- a/iluflex_tools/core/services.py
+++ b/iluflex_tools/core/services.py
@@ -25,6 +25,9 @@ class ConnectionService:
         self._stop = threading.Event()
         self._remote = ("", 0)
         self._listeners: List[Callable[[Dict[str, Any]], None]] = []
+        self._auto_thread: threading.Thread | None = None
+        self._auto_stop = threading.Event()
+        self._auto_interval = 5.0
 
     # ---- listeners ----
     def add_listener(self, cb: Callable[[Dict[str, Any]], None]):
@@ -45,6 +48,7 @@ class ConnectionService:
     # ---- conexão ----
     def connect(self, ip: str, port: int, timeout: float = 3.0) -> bool:
         self.disconnect()  # encerra conexão anterior, se houver
+        self._remote = (ip, port)
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(timeout)
@@ -52,7 +56,6 @@ class ConnectionService:
             s.connect((ip, port))
             s.settimeout(0.5)
             self._sock = s
-            self._remote = (ip, port)
             self.connected = True
             self._stop.clear()
             self._rx_thread = threading.Thread(target=self._recv_loop, daemon=True)
@@ -68,6 +71,31 @@ class ConnectionService:
             self._sock = None
             self.connected = False
             return False
+
+    def auto_reconnect(self, interval: float = 5.0):
+        """Tenta reconectar periodicamente após desconexão."""
+        self._auto_interval = max(0.1, interval)
+        # encerra thread anterior, se houver
+        self._auto_stop.set()
+        if self._auto_thread and self._auto_thread.is_alive():
+            try:
+                self._auto_thread.join(timeout=0)
+            except Exception:
+                pass
+        self._auto_stop.clear()
+        self._auto_thread = threading.Thread(target=self._auto_loop, daemon=True)
+        self._auto_thread.start()
+
+    def stop_auto_reconnect(self):
+        self._auto_stop.set()
+
+    def _auto_loop(self):
+        while not self._auto_stop.wait(self._auto_interval):
+            if self.connected:
+                continue
+            ip, port = self._remote
+            if ip and port:
+                self.connect(ip, port)
 
     def disconnect(self):
         if self._sock:

--- a/iluflex_tools/ui/pages/comandos_ir.py
+++ b/iluflex_tools/ui/pages/comandos_ir.py
@@ -82,6 +82,8 @@ class ComandosIRPage(ctk.CTkFrame):
         sendcmd_frame = ctk.CTkFrame(self)
         sendcmd_frame.grid(row=8, column=0, sticky="ew", padx=10, pady=(8,10))
         sendcmd_frame.grid_columnconfigure(5, weight=1)
+        self.auto_reconnect = ctk.CTkSwitch(sendcmd_frame, text="Auto reconectar", command=self._toggle_auto_reconnect)
+        self.auto_reconnect.pack(side="left", padx=(0, 8))
         self.entry = ctk.CTkEntry(sendcmd_frame, placeholder_text="Digite o comando a enviar...", width=600)
         self.entry.pack(side="left", padx=(0, 8))
         ctk.CTkButton(sendcmd_frame, text="Enviar", command=self._send).pack(side="left", padx=(0, 8))
@@ -135,8 +137,17 @@ class ComandosIRPage(ctk.CTkFrame):
         if not ok:
             self._append("[warn] não conectado; mensagem não enviada.\n")
 
+    def _toggle_auto_reconnect(self):
+        try:
+            if self.auto_reconnect.get():
+                self.conn.auto_reconnect()
+            else:
+                self.conn.stop_auto_reconnect()
+        except Exception:
+            pass
+
     def _clear(self):
-            self.status.configure(text="")
+        self.status.configure(text="")
 
     # ---- eventos da conexão ----
     def _on_conn_event(self, ev: dict):

--- a/iluflex_tools/ui/pages/conexao.py
+++ b/iluflex_tools/ui/pages/conexao.py
@@ -79,6 +79,8 @@ class ConexaoPage(ctk.CTkFrame):
 
         btns = ctk.CTkFrame(self)
         btns.grid(row=4, column=0, columnspan=3, pady=8)
+        self.auto_reconnect = ctk.CTkSwitch(btns, text="Auto reconectar")
+        self.auto_reconnect.pack(side="left", padx=6)
         ctk.CTkButton(btns, text="Conectar", command=self._connect).pack(side="left", padx=6)
         ctk.CTkButton(btns, text="Desconectar", command=self._disconnect).pack(side="left", padx=6)
 
@@ -100,10 +102,21 @@ class ConexaoPage(ctk.CTkFrame):
         ip = self.ip_entry.get().strip()
         port = int(self.port_entry.get().strip() or 0)
         ok = self.on_connect(ip, port)
+        try:
+            if self.auto_reconnect.get():
+                self._conn.auto_reconnect()
+            else:
+                self._conn.stop_auto_reconnect()
+        except Exception:
+            pass
         self.status.configure(text=f"Conectado a {ip}:{port}" if ok else "Falha na conexão")
 
     def _disconnect(self):
         self.on_disconnect()
+        try:
+            self._conn.stop_auto_reconnect()
+        except Exception:
+            pass
         self.status.configure(text="Desconectado.")
 
     def _buscar(self):

--- a/iluflex_tools/ui/pages/gestao_dispositivos.py
+++ b/iluflex_tools/ui/pages/gestao_dispositivos.py
@@ -58,6 +58,8 @@ class GestaoDispositivosPage(ctk.CTkFrame):
         ).pack(side="left", padx=(4, 12))
 
         ctk.CTkButton(bar, text="ATUALIZAR LISTA", command=self._on_click_atualizar).pack(side="left", padx=6)
+        self.auto_reconnect = ctk.CTkSwitch(bar, text="Auto reconectar", command=self._toggle_auto_reconnect)
+        self.auto_reconnect.pack(side="left", padx=6)
 
         # Tabela
         cols = [
@@ -91,6 +93,15 @@ class GestaoDispositivosPage(ctk.CTkFrame):
                 self.table.enable_header_sort()
             except Exception:
                 pass
+
+    def _toggle_auto_reconnect(self):
+        try:
+            if self.auto_reconnect.get():
+                self._conn.auto_reconnect()
+            else:
+                self._conn.stop_auto_reconnect()
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     # Ingestão de RRF,10


### PR DESCRIPTION
## Summary
- add auto reconnect loop in `ConnectionService`
- expose auto reconnect switch in connection-related pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a10e9a0e30832592693e88c5a7f38b