### PR TITLE
Add RX buffer and message parsing

### DIFF
--- a/iluflex_tools/core/services.py
+++ b/iluflex_tools/core/services.py
@@ -30,6 +30,7 @@ class ConnectionService:
         self._auto_interval = 5.0
         self._listener_lock = threading.Lock()
         self._auto_reconnect_enabled = False  # quando True, desconexões disparam auto‑reconnect
+        self._rx_buffer = bytearray()
 
     # ---- listeners ----
     def add_listener(self, cb: Callable[[Dict[str, Any]], None]):
@@ -152,10 +153,30 @@ class ConnectionService:
                 if not data:
                     print("[RX] conexão encerrada pelo remoto")
                     break
-                ts = datetime.now().strftime("%H:%M:%S.%f")[:-3]
-                text = data.decode("utf-8", errors="replace")
-                print(f"[{ts}] RX {self._remote[0]}:{self._remote[1]} -> {text}")
-                self._emit({"type": "rx", "ts": ts, "remote": self._remote, "text": text, "raw": data})
+                self._rx_buffer.extend(data)
+                while True:
+                    if not self._rx_buffer:
+                        break
+                    if self._rx_buffer[0] == 0xA5:
+                        # Binary frame: A5 <opcode> <len> <payload...> <checksum>
+                        if len(self._rx_buffer) < 3:
+                            break
+                        payload_len = self._rx_buffer[2]
+                        total_len = 4 + payload_len
+                        if len(self._rx_buffer) < total_len:
+                            break
+                        msg = bytes(self._rx_buffer[:total_len])
+                        del self._rx_buffer[:total_len]
+                    else:
+                        idx = self._rx_buffer.find(b"\r")
+                        if idx == -1:
+                            break
+                        msg = bytes(self._rx_buffer[:idx + 1])
+                        del self._rx_buffer[:idx + 1]
+                    ts = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                    text = msg.decode("utf-8", errors="replace")
+                    print(f"[{ts}] RX {self._remote[0]}:{self._remote[1]} -> {text}")
+                    self._emit({"type": "rx", "ts": ts, "remote": self._remote, "text": text, "raw": msg})
             except socket.timeout:
                 continue
             except OSError:


### PR DESCRIPTION
## Summary
- add receive bytearray buffer to `ConnectionService`
- parse buffered data into CR-terminated ASCII and 0xA5-prefixed binary messages with opcode and length
- test rx parsing of ASCII and binary messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b15225c08325903aebe5fba34065