### PR TITLE
Add reusable page title widget and standardize page headers

### DIFF
--- a/iluflex_tools/ui/pages/ajuda.py
+++ b/iluflex_tools/ui/pages/ajuda.py
@@ -1,7 +1,11 @@
 import customtkinter as ctk
+from iluflex_tools.widgets.page_title import PageTitle
+
 
 class AjudaPage(ctk.CTkFrame):
     def __init__(self, master):
         super().__init__(master)
-        ctk.CTkLabel(self, text='Ajuda', font=ctk.CTkFont(size=18, weight='bold')).pack(pady=12, anchor='w', padx=10)
-        ctk.CTkLabel(self, text='(conteúdo a implementar)').pack(pady=6)
+        PageTitle(self, "Ajuda")
+        ctk.CTkLabel(self, text="(conteúdo a implementar)").grid(
+            row=1, column=0, padx=12, pady=6, sticky="w"
+        )

--- a/iluflex_tools/ui/pages/comandos_ir.py
+++ b/iluflex_tools/ui/pages/comandos_ir.py
@@ -3,6 +3,7 @@ from iluflex_tools.widgets.waveform_canvas import WaveformCanvas
 from iluflex_tools.widgets.cards import DropDownCard as dpc
 from iluflex_tools.core.ircode import IrCodeLib
 from iluflex_tools.widgets.buttontags import ButtonTagsWidget
+from iluflex_tools.widgets.page_title import PageTitle
 
 class ComandosIRPage(ctk.CTkFrame):
     """
@@ -44,12 +45,11 @@ class ComandosIRPage(ctk.CTkFrame):
 
     def _build(self):
         # Título
-        self.pagetitle = ctk.CTkLabel(
+        self.pagetitle = PageTitle(
             self,
-            text="IR Learner - Captura de comandos de Infra Vermelho (IR)",
-            font=ctk.CTkFont(size=16, weight="bold"),
+            "IR Learner - Captura de comandos de Infra Vermelho (IR)",
+            columnspan=2,
         )
-        self.pagetitle.grid(row=0, column=0, columnspan=2, padx=12, pady=6, sticky="w")
 
         # Painéis
         leftpanel = ctk.CTkFrame(self)

--- a/iluflex_tools/ui/pages/conexao.py
+++ b/iluflex_tools/ui/pages/conexao.py
@@ -3,6 +3,7 @@ import customtkinter as ctk
 from iluflex_tools.widgets.table_tree import ColumnToggleTree
 from iluflex_tools.core.services import ConnectionService
 from iluflex_tools.widgets.status_led import StatusLed
+from iluflex_tools.widgets.page_title import PageTitle
 
 TABLE_FONT_SIZE = 12
 
@@ -27,9 +28,7 @@ class ConexaoPage(ctk.CTkFrame):
         self.grid_columnconfigure(1, weight=1)
         self.grid_rowconfigure(3, weight=1)
 
-        ctk.CTkLabel(self, text="Conexão de Rede", font=ctk.CTkFont(size=18, weight="bold")).grid(
-            row=0, column=0, columnspan=3, padx=10, pady=(10, 12), sticky="w"
-        )
+        PageTitle(self, "Conexão de Rede", columnspan=3)
 
         conn_frame = ctk.CTkFrame(self)
         conn_frame.grid(row=1, column=0, columnspan=3, padx = 6, pady=10, sticky="ew")

--- a/iluflex_tools/ui/pages/configuracoes.py
+++ b/iluflex_tools/ui/pages/configuracoes.py
@@ -1,5 +1,6 @@
 import customtkinter as ctk
 from iluflex_tools.core.settings import load_settings, save_settings
+from iluflex_tools.widgets.page_title import PageTitle
 
 class PreferenciasPage(ctk.CTkFrame):
     def __init__(self, master, get_settings):
@@ -10,27 +11,34 @@ class PreferenciasPage(ctk.CTkFrame):
     def _build(self):
         s = self.get_settings()
 
-        ctk.CTkLabel(self, text="Preferências", font=ctk.CTkFont(size=18, weight="bold")).pack(pady=(12,8), anchor="w", padx=10)
+        PageTitle(self, "Preferências")
 
-        row1 = ctk.CTkFrame(self); row1.pack(fill="x", padx=10, pady=6)
-        ctk.CTkLabel(row1, text="Tema").pack(side="left", padx=(6,8))
+        row1 = ctk.CTkFrame(self)
+        row1.grid(row=1, column=0, padx=10, pady=6, sticky="w")
+        ctk.CTkLabel(row1, text="Tema").pack(side="left", padx=(6, 8))
         self.option_theme = ctk.CTkOptionMenu(row1, values=["system", "dark", "light"])
         self.option_theme.set(s.theme)
         self.option_theme.pack(side="left")
 
-        row2 = ctk.CTkFrame(self); row2.pack(fill="x", padx=10, pady=6)
-        ctk.CTkLabel(row2, text="Tempo padrão de busca de interfaces (ms)").pack(side="left", padx=(6,8))
+        row2 = ctk.CTkFrame(self)
+        row2.grid(row=2, column=0, padx=10, pady=6, sticky="w")
+        ctk.CTkLabel(row2, text="Tempo padrão de busca de interfaces (ms)").pack(side="left", padx=(6, 8))
         self.timeout = ctk.CTkEntry(row2, width=120)
         self.timeout.insert(0, str(s.discovery_timeout_ms))
         self.timeout.pack(side="left")
 
-        row3 = ctk.CTkFrame(self); row3.pack(fill="x", padx=10, pady=6)
-        ctk.CTkLabel(row3, text="Tempo Padrão de Cadastro de Novos Dispositivos (segundos)").pack(side="left", padx=(6,8))
-        self.discover_timeout_entry = ctk.CTkEntry(row3, width=120); 
+        row3 = ctk.CTkFrame(self)
+        row3.grid(row=3, column=0, padx=10, pady=6, sticky="w")
+        ctk.CTkLabel(row3, text="Tempo Padrão de Cadastro de Novos Dispositivos (segundos)").pack(
+            side="left", padx=(6, 8)
+        )
+        self.discover_timeout_entry = ctk.CTkEntry(row3, width=120)
         self.discover_timeout_entry.insert(0, str(s.mesh_discovery_timeout_sec))
         self.discover_timeout_entry.pack(side="left")
 
-        ctk.CTkButton(self, text="Salvar", command=self._save).pack(pady=12, padx=10, anchor="w")
+        ctk.CTkButton(self, text="Salvar", command=self._save).grid(
+            row=4, column=0, padx=10, pady=12, sticky="w"
+        )
 
     def _save(self):
         s = load_settings()

--- a/iluflex_tools/ui/pages/configurar_master.py
+++ b/iluflex_tools/ui/pages/configurar_master.py
@@ -1,7 +1,11 @@
 import customtkinter as ctk
+from iluflex_tools.widgets.page_title import PageTitle
+
 
 class ConfigurarMasterPage(ctk.CTkFrame):
     def __init__(self, master):
         super().__init__(master)
-        ctk.CTkLabel(self, text='Configurar Master', font=ctk.CTkFont(size=18, weight='bold')).pack(pady=12, anchor='w', padx=10)
-        ctk.CTkLabel(self, text='(conteúdo a implementar)').pack(pady=6)
+        PageTitle(self, "Configurar Master")
+        ctk.CTkLabel(self, text="(conteúdo a implementar)").grid(
+            row=1, column=0, padx=12, pady=6, sticky="w"
+        )

--- a/iluflex_tools/ui/pages/dashboard.py
+++ b/iluflex_tools/ui/pages/dashboard.py
@@ -1,6 +1,7 @@
 import customtkinter as ctk
 from PIL import Image
 import os
+from iluflex_tools.widgets.page_title import PageTitle
 
 class DashboardPage(ctk.CTkFrame):
     """
@@ -31,10 +32,10 @@ class DashboardPage(ctk.CTkFrame):
         self._build_logo()
 
         # título "ATALHOS"
-        self.shortcuts_title = ctk.CTkLabel(
-            self, text="ATALHOS", text_color="#111827", bg_color="#F5F6F8"
+        self.shortcuts_title = PageTitle(
+            self, "ATALHOS", row=3, column=0, pady=(6, 6), sticky="n", padx=0
         )
-        self.shortcuts_title.grid(row=3, column=0, sticky="n", pady=(6, 6))
+        self.shortcuts_title.configure(text_color="#111827", bg_color="#F5F6F8")
 
         # container dos botões
         self.grid_wrap = ctk.CTkFrame(self, fg_color="#F5F6F8")

--- a/iluflex_tools/ui/pages/fw_upgrade.py
+++ b/iluflex_tools/ui/pages/fw_upgrade.py
@@ -1,5 +1,6 @@
 import customtkinter as ctk
 from tkinter import filedialog
+from iluflex_tools.widgets.page_title import PageTitle
 
 class FWUpgradePage(ctk.CTkFrame):
     def __init__(self, master, run_ota):
@@ -8,12 +9,17 @@ class FWUpgradePage(ctk.CTkFrame):
         self._build()
 
     def _build(self):
-        ctk.CTkLabel(self, text="Atualização de Firmware", font=ctk.CTkFont(size=18, weight="bold")).pack(pady=(10,6))
-        row = ctk.CTkFrame(self); row.pack(pady=10, fill="x")
-        self.path_entry = ctk.CTkEntry(row); self.path_entry.pack(side="left", padx=6, expand=True, fill="x")
+        PageTitle(self, "Atualização de Firmware")
+        row = ctk.CTkFrame(self)
+        row.grid(row=1, column=0, pady=10, padx=10, sticky="ew")
+        self.path_entry = ctk.CTkEntry(row)
+        self.path_entry.pack(side="left", padx=6, expand=True, fill="x")
         ctk.CTkButton(row, text="Selecionar .frw", command=self._pick).pack(side="left", padx=6)
-        ctk.CTkButton(self, text="Atualizar", command=self._run).pack(pady=6)
-        self.log = ctk.CTkTextbox(self, height=160); self.log.pack(fill="both", expand=True, padx=6, pady=6)
+        ctk.CTkButton(self, text="Atualizar", command=self._run).grid(row=2, column=0, pady=6)
+        self.log = ctk.CTkTextbox(self, height=160)
+        self.log.grid(row=3, column=0, padx=6, pady=6, sticky="nsew")
+        self.grid_rowconfigure(3, weight=1)
+        self.grid_columnconfigure(0, weight=1)
 
     def _pick(self):
         p = filedialog.askopenfilename(title="Escolher firmware", filetypes=[("Firmware","*.frw"), ("Todos","*.*")])

--- a/iluflex_tools/ui/pages/gestao_dispositivos.py
+++ b/iluflex_tools/ui/pages/gestao_dispositivos.py
@@ -16,6 +16,7 @@ from tkinter import font as tkfont
 from iluflex_tools.widgets.table_tree import ColumnToggleTree
 from iluflex_tools.core.services import ConnectionService, parse_rrf10_lines
 from iluflex_tools.core.settings import load_settings, save_settings
+from iluflex_tools.widgets.page_title import PageTitle
 import time
 import re
 
@@ -63,8 +64,7 @@ class GestaoDispositivosPage(ctk.CTkFrame):
         #bar.grid(row=0, column=0, sticky="ew", padx=10, pady=(10, 6))
         #bar.grid_columnconfigure(9, weight=1)
 
-        self.pagetitle = ctk.CTkLabel(self, text="Gestão de Dispositivos", font=ctk.CTkFont(size=16, weight="bold"))
-        self.pagetitle.grid(row=0, column=0, padx=12, pady=6, sticky='w')
+        self.pagetitle = PageTitle(self, "Gestão de Dispositivos")
                                   
         #).pack(side="left", padx=(4, 12))
 

--- a/iluflex_tools/ui/pages/interface_programacao.py
+++ b/iluflex_tools/ui/pages/interface_programacao.py
@@ -1,7 +1,11 @@
 import customtkinter as ctk
+from iluflex_tools.widgets.page_title import PageTitle
+
 
 class InterfaceProgramacaoPage(ctk.CTkFrame):
     def __init__(self, master):
         super().__init__(master)
-        ctk.CTkLabel(self, text='Interface de Programação', font=ctk.CTkFont(size=18, weight='bold')).pack(pady=12, anchor='w', padx=10)
-        ctk.CTkLabel(self, text='(conteúdo a implementar)').pack(pady=6)
+        PageTitle(self, "Interface de Programação")
+        ctk.CTkLabel(self, text="(conteúdo a implementar)").grid(
+            row=1, column=0, padx=12, pady=6, sticky="w"
+        )

--- a/iluflex_tools/widgets/page_title.py
+++ b/iluflex_tools/widgets/page_title.py
@@ -1,0 +1,9 @@
+import customtkinter as ctk
+
+class PageTitle(ctk.CTkLabel):
+    """Helper label for page titles with consistent style and placement."""
+    def __init__(self, master, text: str, **grid_kwargs):
+        super().__init__(master, text=text, font=ctk.CTkFont(size=18, weight="bold"))
+        opts = {"row": 0, "column": 0, "padx": 12, "pady": (10, 6), "sticky": "w"}
+        opts.update(grid_kwargs)
+        self.grid(**opts)


### PR DESCRIPTION
## Summary
- add `PageTitle` widget for consistent page titles
- switch all UI pages to use the helper for uniform headers

## Testing
- `python -m py_compile iluflex_tools/widgets/page_title.py iluflex_tools/ui/pages/ajuda.py iluflex_tools/ui/pages/comandos_ir.py iluflex_tools/ui/pages/configurar_master.py iluflex_tools/ui/pages/conexao.py iluflex_tools/ui/pages/configuracoes.py iluflex_tools/ui/pages/fw_upgrade.py iluflex_tools/ui/pages/gestao_dispositivos.py iluflex_tools/ui/pages/interface_programacao.py iluflex_tools/ui/pages/dashboard.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6555b65d8832586a12e1eb380952a